### PR TITLE
Homepage profile links + site-wide academic polish

### DIFF
--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -27,6 +27,14 @@ a {
   outline-offset: 2px;
 }
 
+// Comfortable reading measure for long-form pages (CV, Research, Teaching,
+// individual projects) — centered, without touching the home two-column layout.
+.page__content,
+.post__content {
+  @apply mx-auto;
+  max-width: 46rem;
+}
+
 .main {
   display: flex;
   flex-direction: column;

--- a/app/components/partials/footer.vue
+++ b/app/components/partials/footer.vue
@@ -1,6 +1,29 @@
 <template>
   <footer class="footer -mx-4 md:mx-0">
-    <div class="container mx-auto pb-6 flex justify-center">
+    <div class="container mx-auto py-8 px-4 flex flex-col items-center text-center">
+      <nav class="footer__links" aria-label="Contact and academic profiles">
+        <a class="footer__link" href="mailto:zeyd@koytak.com">Email</a>
+        <span class="footer__sep" aria-hidden="true">·</span>
+        <a
+          class="footer__link"
+          href="https://scholar.google.com/citations?user=nestUyQAAAAJ&hl=en"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Scholar
+        </a>
+        <span class="footer__sep" aria-hidden="true">·</span>
+        <a
+          class="footer__link"
+          href="https://orcid.org/0000-0003-1767-0695"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ORCID
+        </a>
+      </nav>
+
+      <p class="footer__copy">&copy; {{ year }} Huseyin Zeyd Koytak</p>
     </div>
   </footer>
 </template>
@@ -9,11 +32,39 @@
 import { Component, Vue } from 'nuxt-property-decorator';
 
 @Component
-export default class Footer extends Vue {}
+export default class Footer extends Vue {
+  year: number = new Date().getFullYear();
+}
 </script>
 
 <style lang="scss">
 .footer {
   background-color: $bluise;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.footer__links {
+  @apply flex flex-wrap items-center justify-center;
+  font-size: 0.92rem;
+}
+
+.footer__link {
+  @apply font-medium px-1;
+  color: rgba(255, 255, 255, 0.85);
+  transition: color 0.18s ease;
+
+  &:hover {
+    color: #fff;
+  }
+}
+
+.footer__sep {
+  @apply mx-2;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.footer__copy {
+  @apply text-sm mt-3;
+  color: rgba(255, 255, 255, 0.65);
 }
 </style>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,16 +1,66 @@
-
 <template>
   <section class="home">
-    <div class="container mx-auto py-12 md:py-24 flex flex-wrap items-center">
+    <div class="container mx-auto py-12 md:py-24 flex flex-wrap md:items-start">
       <div class="w-full md:w-3/5 flex flex-col justify-center items-start px-4 md:px-8">
         <div v-html="$md.render(welcomeText)" class="home__welcome markdown" />
       </div>
-      <div class="w-full md:w-2/5 flex justify-center md:justify-start mt-10 md:mt-0">
+
+      <div class="w-full md:w-2/5 flex flex-col items-center mt-10 md:mt-0 px-4 md:px-8">
         <img
           alt="Huseyin Zeyd Koytak"
-          class="rounded shadow-xl max-w-full h-auto w-65 md:w-80 lg:w-96"
-          src="http://www.koytak.com/images/uploads/hzk.jpg"
+          class="profile-photo rounded shadow-xl max-w-full h-auto w-56 sm:w-64 md:w-72 lg:w-80"
+          src="/images/uploads/hzk.jpg"
         />
+
+        <nav class="profile-links mt-5" aria-label="Academic profiles">
+          <a
+            class="profile-link"
+            href="https://scholar.google.com/citations?user=nestUyQAAAAJ&hl=en"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <svg
+              class="profile-link__icon"
+              viewBox="0 0 24 24"
+              width="16"
+              height="16"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                d="M12 24a7 7 0 1 1 0-14 7 7 0 0 1 0 14zm0-24L0 9.5l4.838 3.94A8 8 0 0 1 12 9a8 8 0 0 1 7.162 4.44L24 9.5z"
+              />
+            </svg>
+            <span>Google Scholar</span>
+          </a>
+
+          <span class="profile-links__sep" aria-hidden="true">·</span>
+
+          <a
+            class="profile-link"
+            href="https://orcid.org/0000-0003-1767-0695"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <svg
+              class="profile-link__icon"
+              viewBox="0 0 256 256"
+              width="16"
+              height="16"
+              aria-hidden="true"
+            >
+              <path
+                fill="#A6CE39"
+                d="M256 128c0 70.7-57.3 128-128 128S0 198.7 0 128 57.3 0 128 0s128 57.3 128 128z"
+              />
+              <path
+                fill="#FFF"
+                d="M86.3 186.2H70.9V79.1h15.4v107.1zM108.9 79.1h41.6c39.6 0 57 28.3 57 53.6 0 27.5-21.5 53.6-56.8 53.6h-41.8V79.1zm15.4 93.3h24.5c34.9 0 42.9-26.5 42.9-39.7 0-21.5-13.7-39.7-43.7-39.7h-23.7v79.4zM88.7 56.8c0 5.5-4.5 10.1-10.1 10.1s-10.1-4.6-10.1-10.1c0-5.6 4.5-10.1 10.1-10.1s10.1 4.6 10.1 10.1z"
+              />
+            </svg>
+            <span>ORCID</span>
+          </a>
+        </nav>
       </div>
     </div>
   </section>
@@ -35,21 +85,42 @@ export default class Home extends Vue {
   }
 
   isSignedUp = false;
-
-
 }
 </script>
 
 <style lang="scss" scoped>
-.home {
-  img {
-    box-shadow: 0 18px 40px -14px rgba(11, 55, 101, 0.4);
-    transition: transform 0.35s ease, box-shadow 0.35s ease;
-  }
+.profile-photo {
+  box-shadow: 0 18px 40px -14px rgba(11, 55, 101, 0.4);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
 
-  img:hover {
+  &:hover {
     transform: translateY(-5px);
     box-shadow: 0 26px 52px -14px rgba(11, 55, 101, 0.5);
   }
+}
+
+.profile-links {
+  @apply flex items-center justify-center;
+  font-size: 0.9rem;
+}
+
+.profile-link {
+  @apply inline-flex items-center font-medium;
+  color: $ink;
+  transition: color 0.18s ease;
+
+  &:hover {
+    color: $bluise;
+  }
+}
+
+.profile-link__icon {
+  @apply mr-2 flex-shrink-0;
+  color: $bluise;
+}
+
+.profile-links__sep {
+  @apply mx-3;
+  color: #cbd5e0;
 }
 </style>

--- a/app/pages/projects/_slug.vue
+++ b/app/pages/projects/_slug.vue
@@ -4,6 +4,7 @@
       <h1 class="text-lg md:text-xl lg:text-4xl xl:text-6xl">
         {{ post.title }}
       </h1>
+      <p v-if="post.publishedAt" class="post__date">{{ post.publishedAt }}</p>
     </div>
 
     <div v-html="$md.render(post.content)" class="post__content markdown pt-4 md:pt-6 md:pb-24" />
@@ -53,3 +54,10 @@ export default class BlogPost extends Vue {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.post__date {
+  @apply text-sm mt-3;
+  color: #718096;
+}
+</style>

--- a/app/pages/projects/index.vue
+++ b/app/pages/projects/index.vue
@@ -12,10 +12,12 @@
         <nuxt-link :to="`/projects/${post.slug}`" class="project-link">
           <img
             :alt="post.title"
+            loading="lazy"
             class="project-thumb flex-shrink-0 object-cover rounded w-24 h-16 sm:w-32 sm:h-20"
             :src="post.featuredImage || 'https://source.unsplash.com/random/320x200'"
           />
           <div class="project-body min-w-0">
+            <p v-if="post.publishedAt" class="project-date">{{ post.publishedAt }}</p>
             <h3 class="project-title">{{ post.title }}</h3>
             <p class="project-excerpt">{{ post.excerpt }}</p>
             <span class="project-more">Read more &rarr;</span>
@@ -115,6 +117,12 @@ export default class BlogIndex extends Vue {
 
 .project-body {
   @apply ml-4 sm:ml-5;
+}
+
+.project-date {
+  @apply text-xs font-medium uppercase mb-1;
+  color: #a0aec0;
+  letter-spacing: 0.05em;
 }
 
 .project-title {

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -26,6 +26,7 @@ export async function getContent({ context, prefix }): Promise<{ slug: string; t
       title: entry.title,
       ...(prefix === 'blog' && {
         excerpt: createExcerpt({ text: entry.content }),
+        publishedAt: entry.publishedAt,
       }),
       featuredImage: entry.featuredImage,
     });


### PR DESCRIPTION
Builds on the merged design work. Keeps the simple, academic aesthetic and adds quality touches.

## Homepage
- **Portrait repositioned** — top-aligned two-column layout, photo centered in its column, and now served **locally over HTTPS** (`/images/uploads/hzk.jpg`) instead of a hard-coded `http://www.koytak.com/...` URL (also fixes mixed-content).
- **Google Scholar + ORCID links beneath the photo**, with small inline icons (brand-blue Scholar mark, official green ORCID iD), opening in a new tab.

## Site-wide (unobtrusive)
- **Footer** — the empty blue bar is now a minimal footer: **Email · Google Scholar · ORCID** links + a `© {year} Huseyin Zeyd Koytak` line.
- **Readability** — long-form pages (CV, Research, Teaching, individual projects) are constrained to a comfortable **~46rem measure**, centered. The home two-column layout is untouched.
- **Projects** — list items and project pages now show the **publication date**, and list thumbnails are **lazy-loaded**.

## Preview
Please check on the Netlify Deploy Preview: homepage photo + Scholar/ORCID links, the new footer on every page, a project page's date, and line length on the CV/Research pages. Hard-refresh to bypass cached CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)