### PR TITLE
Fix Netlify build (responsive @apply) — restores deploys

### DIFF
--- a/app/pages/projects/index.vue
+++ b/app/pages/projects/index.vue
@@ -116,7 +116,13 @@ export default class BlogIndex extends Vue {
 }
 
 .project-body {
-  @apply ml-4 sm:ml-5;
+  margin-left: 1rem;
+}
+
+@media (min-width: 640px) {
+  .project-body {
+    margin-left: 1.25rem;
+  }
 }
 
 .project-date {
@@ -126,10 +132,17 @@ export default class BlogIndex extends Vue {
 }
 
 .project-title {
-  @apply text-base sm:text-lg font-semibold leading-snug;
+  @apply font-semibold leading-snug;
+  font-size: 1rem;
   color: $ink;
   letter-spacing: -0.01em;
   transition: color 0.18s ease;
+}
+
+@media (min-width: 640px) {
+  .project-title {
+    font-size: 1.125rem;
+  }
 }
 
 .project-excerpt {


### PR DESCRIPTION
## Why the site stopped updating
`yarn generate` has been **failing** since the `/projects` compact-list change (PR #80) landed, with:

```
`@apply` cannot be used with `.sm:ml-5` ... its actual definition includes a pseudo-selector
```

This Tailwind setup can't `@apply` responsive variants (`sm:*`). Because the build errored, Netlify kept serving the **last good deploy** — so #80 and #81 never went live, and it looked like "nothing changes no matter what we push." **It's not a Netlify problem; it's a build error.**

## Fix
Replace the two offending rules in `app/pages/projects/index.vue` with equivalent base CSS + a `@media (min-width: 640px)` query. Identical visual result, build succeeds.

## After merging
Merging this **restores deploys** and finally publishes everything already merged (projects at `/projects`, compact list, footer, homepage Scholar/ORCID links, readability). Watch the Deploy Preview check on this PR go green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)